### PR TITLE
Updating resolver repository for cogcomp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,7 @@ lazy val commonSettings = Seq(
     ),
   resolvers ++= Seq(
     Resolver.mavenLocal,
-    "CogcompSoftware" at "http://cogcomp.cs.illinois.edu/m2repo/"
+    "CogcompSoftware" at "https://cogcomp.seas.upenn.edu/m2repo/"
   )
 )
 


### PR DESCRIPTION
The old address is not operational & breaking the build.